### PR TITLE
add: clangd LSP support

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,11 @@
+CompileFlags:
+    Remove: [
+        -fconserve-stack, 
+        -mpreferred-stack-boundary=*, 
+        -mno-fp-ret-in-387,
+        -mindirect-branch=thunk-extern,
+        -mindirect-branch-register,
+        -fno-allow-store-data-races,
+        -fsanitize=bounds-strict,
+        -mrecord-mcount,
+    ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,19 @@
 hrp_venv/
 
+# kernel modules
+*.o
+*.o.cmd
+*.ko.cmd
+*.mod.cmd
+*.order.cmd
+*.order
+*.mod
+*.ko
+*.mod.c
+*.symvers
+*.symvers.cmd
+
+
+# clangd 
+.cache/
+compile_commands.json


### PR DESCRIPTION
Support using clangd as the LSP for the development.

I tested with `bear` for compilation database generation. There are some flags that clangd should ignore during LSP initialization.

To generate the compilation database for clangd.
``` bash
bear -- make
```

Might be a good idea to have a makefile recipe to run the command instead.