### PR TITLE
Add support for using TSC as the timestamp

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -1,0 +1,12 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <linux/ioctl.h>
+#include <linux/stddef.h>
+#include <linux/types.h>
+#include <linux/align.h>
+
+#define CACHE_LINE_SIZE 64
+#define ALIGN_TO_CACHE_LINE __aligned(CACHE_LINE_SIZE)
+
+#endif // COMMON_H

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -3,10 +3,15 @@
 
 #include <linux/types.h>
 #include <linux/ktime.h>
+
 #include "config.h"
 
 typedef struct {
+#ifdef HRP_USE_TSC
+    u64 kts;
+#else
     ktime_t kts;
+#endif
     unsigned long long stall_mem;
     unsigned long long inst_retire;
     unsigned long long cpu_unhalt;

--- a/src/config.h
+++ b/src/config.h
@@ -24,6 +24,10 @@
 // LDB timestamps use the raw clock, also corresponding to perf sched record -k CLOCK_MONOTONIC_RAW
 #define HRP_USE_RAW_CLOCK 0
 
+// 1 for using rdtsc for timestamping, 0 for using ktime_get
+// if set to 1, the HRP_USE_RAW_CLOCK flag will be ignored.
+#define HRP_USE_TSC 0
+
 // set to 1 to enable user space polling via RDPMC
 #define ENABLE_USER_SPACE_POLLING 1
 

--- a/src/config.h
+++ b/src/config.h
@@ -74,8 +74,9 @@ static const unsigned long hrp_pmc_cpu_selection_mask_bits[HRP_PMC_CPU_SELECTION
 #define HRP_PMC_DEVICE_NAME "hrperf_device"
 #define HRP_PMC_CLASS_NAME "hrperf_class"
 #define HRP_PMC_IOC_MAGIC  'k'
-#define HRP_PMC_IOC_START  _IO(HRP_PMC_IOC_MAGIC, 1)
-#define HRP_PMC_IOC_PAUSE   _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_START       _IO(HRP_PMC_IOC_MAGIC, 1)
+#define HRP_PMC_IOC_PAUSE       _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_TSC_FREQ    _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
 
 /*
     BPF Component Configurations, CURRENTLY NOT USED!

--- a/src/hrperf.c
+++ b/src/hrperf.c
@@ -22,6 +22,7 @@
 #include "intel_msr.h"
 #include "intel_pmc.h"
 #include "log.h"
+#include "tsc.h"
 
 // for the poller, logger, and buffers
 static DEFINE_PER_CPU(HrperfRingBuffer, per_cpu_buffer);
@@ -42,13 +43,6 @@ static struct file_operations fops = {
     .owner = THIS_MODULE,
     .unlocked_ioctl = hrperf_ioctl
 };
-
-static inline __attribute__((always_inline)) uint64_t read_tsc(void)
-{
-    uint32_t a, d;
-    asm volatile("rdtsc" : "=a" (a), "=d" (d));
-    return ((uint64_t)a) | (((uint64_t)d) << 32);
-}
 
 static void enable_rdpmc_in_user_space(void *info)
 {
@@ -94,10 +88,14 @@ static void hrperf_pmc_enable_and_esel(void *info) {
 static void hrperf_poller_func(void *info) {
     HrperfLogEntry entry;
     entry.cpu_id = smp_processor_id();
+#ifdef HRP_USE_TSC
+    entry.tick.kts = __rdtsc();
+#else
 #if HRP_USE_RAW_CLOCK
     entry.tick.kts = ktime_get_raw();
 #else
     entry.tick.kts = ktime_get_real();
+#endif
 #endif
     rdmsrl(MSR_IA32_PMC2, entry.tick.stall_mem);
     rdmsrl(MSR_IA32_FIXED_CTR0, entry.tick.inst_retire);
@@ -165,6 +163,13 @@ static long hrperf_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 
 static int __init hrp_pmc_init(void) {
     printk(KERN_INFO "hrperf: Initializing LKM\n");
+    
+    u64 tsc_cycle = hrp_calibrate_tsc();
+    if (tsc_cycle == 0) {
+        pr_err("kHRP: TSC calibration failed.\n");
+        return -EIO;
+    }
+    pr_info("kHRP: TSC cycles per us: %llu\n", tsc_cycle);
 
     // step 1: init char device
     dev_t dev_num = MKDEV(HRP_PMC_MAJOR_NUMBER, 0);

--- a/src/hrperf.c
+++ b/src/hrperf.c
@@ -155,7 +155,6 @@ static long hrperf_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
             printk(KERN_INFO "hrperf: Monitoring paused\n");
         }
         break;
-            
     case HRP_PMC_IOC_TSC_FREQ: {
         if (cycles_per_us == 0) {
             cycles_per_us = hrp_calibrate_tsc();
@@ -178,12 +177,14 @@ static long hrperf_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 static int __init hrp_pmc_init(void) {
     printk(KERN_INFO "hrperf: Initializing LKM\n");
     
+#ifdef HRP_USE_TSC
     u64 tsc_cycle = hrp_calibrate_tsc();
     if (tsc_cycle == 0) {
         pr_err("hrperf: TSC calibration failed.\n");
         return -EIO;
     }
     pr_info("hrperf: TSC cycles per us: %llu\n", tsc_cycle);
+#endif
 
     // step 1: init char device
     dev_t dev_num = MKDEV(HRP_PMC_MAJOR_NUMBER, 0);

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -1,0 +1,97 @@
+#ifndef TSC_H
+#define TSC_H
+
+#include <linux/delay.h>
+#include <linux/ktime.h>
+#include <linux/timekeeping.h>
+#include <linux/types.h>
+
+#include "../include/common.h"
+
+static u64 cycles_per_us ALIGN_TO_CACHE_LINE = 0;
+
+static inline __attribute__((always_inline)) void cpu_serialize(void) {
+  asm volatile("xorl %%eax, %%eax\n\t"
+               "cpuid"
+               :
+               :
+               : "%rax", "%rbx", "%rcx", "%rdx");
+}
+
+static inline __attribute__((always_inline)) u64 __rdtsc(void) {
+  u32 a, d;
+  asm volatile("rdtsc" : "=a"(a), "=d"(d));
+  return ((u64)a) | (((u64)d) << 32);
+}
+
+static inline __attribute__((always_inline)) u64 __rdtscp(uint32_t *auxp) {
+  uint32_t a, d, c;
+  asm volatile("rdtscp" : "=a"(a), "=d"(d), "=c"(c));
+  if (auxp)
+    *auxp = c;
+  return ((u64)a) | (((u64)d) << 32);
+}
+
+/* modified from DPDK implementation */
+/* not used rn */
+static u64 __time_calibrate_tsc(void) {
+  u64 cycles_per_us = 0;
+
+  struct timespec64 t_start, t_end;
+  u64 start, end, ns;
+  double secs;
+
+  cpu_serialize();
+  ktime_get_raw_ts64(&t_start);
+  start = __rdtsc();
+
+  /* Sleep for ~500ms */
+  msleep(500);
+
+  ktime_get_raw_ts64(&t_end);
+  end = __rdtscp(NULL);
+
+  ns = (t_end.tv_sec - t_start.tv_sec) * 1000000000ULL;
+  ns += (t_end.tv_nsec - t_start.tv_nsec);
+
+  secs = (double)ns / 1000.0; // microseconds
+  cycles_per_us = (u64)((end - start) / secs);
+
+  return cycles_per_us;
+}
+
+// Helper function to calibrate TSC frequency (cycles per microsecond)
+static u64 hrp_calibrate_tsc(void) {
+  u64 start_tsc, end_tsc, elapsed_tsc;
+  ktime_t start_time, end_time;
+  s64 elapsed_ns;
+  const unsigned int delay_ms = 500;
+
+  // Prevent migration during measurement
+  preempt_disable();
+  cpu_serialize();
+  start_time = ktime_get();
+  start_tsc = __rdtsc();
+  preempt_enable();
+
+  msleep(delay_ms);
+
+  preempt_disable();
+  end_tsc = __rdtscp(NULL);
+  end_time = ktime_get();
+  preempt_enable();
+
+  elapsed_tsc = end_tsc - start_tsc;
+  elapsed_ns = ktime_to_ns(ktime_sub(end_time, start_time));
+
+  if (elapsed_ns <= 0) {
+    pr_warn("kHRP: TSC calibration failed (elapsed_ns <= 0)\n");
+    return 0;
+  }
+
+  // Calculate cycles per microsecond: (cycles * 1,000) / ns
+  cycles_per_us = div64_u64(elapsed_tsc * 1000, elapsed_ns);
+  return cycles_per_us;
+}
+
+#endif // TSC_H

--- a/src/tsc.h
+++ b/src/tsc.h
@@ -85,7 +85,7 @@ static u64 hrp_calibrate_tsc(void) {
   elapsed_ns = ktime_to_ns(ktime_sub(end_time, start_time));
 
   if (elapsed_ns <= 0) {
-    pr_warn("kHRP: TSC calibration failed (elapsed_ns <= 0)\n");
+    pr_warn("hrperf: TSC calibration failed (elapsed_ns <= 0)\n");
     return 0;
   }
 

--- a/workloads/hrperf_api.h
+++ b/workloads/hrperf_api.h
@@ -1,14 +1,18 @@
 #ifndef _HRPERF_API_H
 #define _HRPERF_API_H
 
+#include <stdint.h>
 #include <stdio.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
+#define u64 uint64_t
+
 #define HRP_PMC_IOC_MAGIC 'k'
-#define HRP_PMC_IOC_START _IO(HRP_PMC_IOC_MAGIC, 1)
-#define HRP_IOC_STOP _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_START       _IO(HRP_PMC_IOC_MAGIC, 1)
+#define HRP_IOC_STOP            _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_TSC_FREQ    _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
 
 int hrperf_start() {
     int fd;
@@ -50,6 +54,33 @@ int hrperf_pause() {
 
     close(fd);
     return 0;
+}
+
+/*
+ * Get the TSC frequency from the kernel module.
+ * The unit is cycles per microsecond.
+*/
+u64 hrperf_get_tsc_freq() {
+
+    int fd;
+    u64 tsc_freq;
+
+    // Open the device file
+    fd = open("/dev/hrperf_device", O_RDWR);
+    if (fd < 0) {
+        perror("open");
+        return 0;
+    }
+
+    // Get the TSC frequency
+    if (ioctl(fd, HRP_PMC_IOC_TSC_FREQ, &tsc_freq) < 0) {
+        perror("ioctl");
+        close(fd);
+        return 0;
+    }
+
+    close(fd);
+    return tsc_freq;
 }
 
 // for the bpf component

--- a/workloads/tsc_freq.c
+++ b/workloads/tsc_freq.c
@@ -1,0 +1,11 @@
+#include "hrperf_api.h"
+
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+int main() {
+    uint64_t freq = hrperf_get_tsc_freq();
+    printf("TSC Frequency (cycles/us): %" PRIu64 "\n", freq);
+    return 0;
+}


### PR DESCRIPTION
Four major changes:
- add: macro flag for using `rdtsc` as the timestamp for the events
- add: perform tsc calibration at kmod initialization time
- add: ioctl for getting calibrated tsc frequency from the kmod
- add: a utility program to read the tsc frequency from the kmod


> [!NOTE]  
> The parsing script also needs some adjustments to work with the tsc-based timestamping.
> Currently, the tsc flag is default to off, so it shall not cause additional confusion for now.
