### PR TITLE
Fix: Correct timestamp logging for tsc, and field name for off core counter

### DIFF
--- a/parsing/parse_hrp.py
+++ b/parsing/parse_hrp.py
@@ -53,10 +53,10 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us):
             ) = struct.unpack(entry_format, data)
 
             # If tsc used, convert tsc to ktime using frequency.
-            if use_tsc_ts:
-                timestamp_ns = int(ktime / tsc_per_us * 1e3)
-            else:
-                timestamp_ns = ktime
+            # if use_tsc_ts:
+            #     timestamp_ns = int(ktime / tsc_per_us * 1e3)
+            # else:
+            #     timestamp_ns = ktime
 
             if cpu_id not in per_core_data:
                 per_core_data[cpu_id] = []
@@ -64,7 +64,7 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us):
             per_core_data[cpu_id].append(
                 {
                     "cpu_id": cpu_id,
-                    "timestamp_ns": timestamp_ns,
+                    "timestamp_ns": ktime,
                     "stall_mem": stall_mem,
                     "inst_retire": inst_retire,
                     "cpu_unhalt": cpu_unhalt,
@@ -126,7 +126,10 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us):
             continue  # Skip the first record for accurate calculations
 
         # Calculate time delta for this core
-        time_delta_ns = current_entry["timestamp_ns"] - state["last_timestamp_ns"]
+        if use_tsc_ts:
+            time_delta_ns = (current_entry["timestamp_ns"] - state["last_timestamp_ns"]) / 1999 * 1e3
+        else:
+            time_delta_ns = current_entry["timestamp_ns"] - state["last_timestamp_ns"]
         time_delta_us = time_delta_ns / 1e3  # Convert ns to us
 
         if time_delta_us <= 0:

--- a/parsing/parse_hrp.py
+++ b/parsing/parse_hrp.py
@@ -192,8 +192,8 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
         }
 
         if use_offcore: 
-            perf_entry["read_misses_rate"] = llc_misses_rate
-            perf_entry["write_misses_rate"] = sw_prefetch_rate
+            perf_entry["offcore_read_rate"] = llc_misses_rate
+            perf_entry["offcore_write_rate"] = sw_prefetch_rate
         else:
             perf_entry["llc_misses_rate"] = llc_misses_rate
             perf_entry["sw_prefetch_rate"] = sw_prefetch_rate
@@ -207,8 +207,8 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
             perf_entry["inst_retire"] = current_entry["inst_retire"]
             perf_entry["cpu_unhalt"] = current_entry["cpu_unhalt"]
             if use_offcore:
-                perf_entry["read_misses"] = current_entry["llc_misses"]
-                perf_entry["write_misses"] = current_entry["sw_prefetch"]
+                perf_entry["offcore_read"] = current_entry["llc_misses"]
+                perf_entry["offcore_write"] = current_entry["sw_prefetch"]
             else:
                 perf_entry["llc_misses"] = current_entry["llc_misses"]
                 perf_entry["sw_prefetch"] = current_entry["sw_prefetch"]
@@ -263,15 +263,15 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
                     "stalls_per_us": "float64",
                     "inst_retire_rate": "float64",
                     "cpu_usage": "float64",
-                    "read_misses_rate": "float64",
-                    "write_misses_rate": "float64",
+                    "offcore_read_rate": "float64",
+                    "offcore_write_rate": "float64",
                     "memory_bandwidth_bytes_per_us": "float64",
                     "time_delta_ns": "int64",
                     "stall_mem": "uint64",
                     "inst_retire": "uint64",
                     "cpu_unhalt": "uint64",
-                    "read_misses": "uint64",
-                    "write_misses": "uint64",
+                    "offcore_read": "uint64",
+                    "offcore_write": "uint64",
                 }
             )
         else:
@@ -304,8 +304,8 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
                     "stalls_per_us": "float64",
                     "inst_retire_rate": "float64",
                     "cpu_usage": "float64",
-                    "read_misses_rate": "float64",
-                    "write_misses_rate": "float64",
+                    "offcore_read_rate": "float64",
+                    "offcore_write_rate": "float64",
                     "memory_bandwidth_bytes_per_us": "float64",
                     "time_delta_ns": "int64",
                 }
@@ -349,15 +349,15 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
                     stalls_per_us DOUBLE,
                     inst_retire_rate DOUBLE,
                     cpu_usage DOUBLE,
-                    read_misses_rate DOUBLE,
-                    write_misses_rate DOUBLE,
+                    offcore_read_rate DOUBLE,
+                    offcore_write_rate DOUBLE,
                     memory_bandwidth_bytes_per_us DOUBLE,
                     time_delta_ns BIGINT,
                     stall_mem BIGINT,
                     inst_retire BIGINT,
                     cpu_unhalt BIGINT,
-                    read_misses BIGINT,
-                    write_misses BIGINT
+                    offcore_read BIGINT,
+                    offcore_write BIGINT
                 )
             """)
         else:
@@ -390,8 +390,8 @@ def parse_hrperf_log(perf_log_path, use_raw, use_tsc_ts, tsc_per_us, use_offcore
                     stalls_per_us DOUBLE,
                     inst_retire_rate DOUBLE,
                     cpu_usage DOUBLE,
-                    read_misses_rate DOUBLE,
-                    write_misses_rate DOUBLE,
+                    offcore_read_rate DOUBLE,
+                    offcore_write_rate DOUBLE,
                     memory_bandwidth_bytes_per_us DOUBLE,
                     time_delta_ns BIGINT
                 )


### PR DESCRIPTION
- Fix 1: Correct timestamp logging when using tsc.
'timestamp_ns' will record the tsc value, 'time_delta_ns' will record the real delta calculated by tsc frequency on particular machine.
- Fix 2: Correct field name when using off core counter.
Added new variable 'use_offcore', it have a value of 1 when hiresperf is using off core counters to log read_misses and write_misses, and to 0 when hiresperf is using llc_misses and sw_prefetch. And pars result will record the corresponding field name.