### PR TITLE
feat: sync poll + support poll poller's PMUs + new instructed profile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ For building LDB-instrumented compiler, see instructions in [the LDB repo](https
 Note that some apps requires further patching (e.g. toggling hiresperf start/pause, hint the compiler to avoid inlining key functions, etc). Such modified source files of each app is included in this repo's `apps/` directory (which is currently not so organized).
 
 **Toggle hiresperf kernel module**
+
+The hiresperf kernel module has two mode --- polling profile and instructed profile. By default, polling profile is used.
+
+- In the polling profile mode, two busy polling threads are spinning to poll the PMUs and log data to the file, respectively.
+- In the instructed profile mode, no busy polling threads are created. The hiresperf kernel module only poll or log data when you instruct it to do so. This can be handy in the case where you don't want the expensive polling cost and only care about the counter delta between two time points.
+
+**Use Polling Profile**
+
 There are two ways, first is including calls to `hrperf_start()`/`hrperf_pause()` in your program, using the C or Python helper functions in `install/`.
 
 The other way is to manually toggle it by
@@ -48,6 +56,29 @@ make
 ./start
 ```
 Either way it's just using `ioctl` to interact with the kernel module.
+
+**Use Instructed Profile**
+
+The instructed profile mode can be enabled when loading the hiresperf kernel module:
+``` bash
+sudo insmod hrperf.ko instructed_profile=y
+```
+
+After that, similarly, you can either invoke `hrperf_poll()`/`hrperf_log()`/`hrperf_poll_log()` in your program or manually use helper program in the `workloads` folder.
+
+For example:For example:
+``` bash
+cd workloads
+
+# Only poll the PMUs across all cores once (the data resides in a in-memory buffer)
+sudo ./instruct_poll
+
+# Or, only log any already polled data into the output file
+sudo ./insturct_log
+
+# Or, poll and log the reading into the output file
+sudo ./instruct_poll_log
+```
 
 **Running the app to profile it**
 Eventually, you will need to compose a command like

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -12,7 +12,7 @@
 #include "buffer.h"
 #include "config.h"
 
-#ifdef HRP_EXLARGE_HEAP_ALLOCATED_RB
+#if HRP_EXLARGE_HEAP_ALLOCATED_RB
 static struct page **buffer_pages;
 static size_t buffer_num_pages = 0;
 
@@ -32,7 +32,7 @@ static void free_alloc_pages(void) {
 static int hrp_alloc_rb_buf(HrperfRingBuffer *rb) {
     HrperfLogEntry *buf = NULL;
     size_t buf_size = HRP_PMC_BUFFER_SIZE * sizeof(HrperfLogEntry);
-#ifdef HRP_EXLARGE_HEAP_ALLOCATED_RB
+#if HRP_EXLARGE_HEAP_ALLOCATED_RB
     unsigned long page_aligned_buf_size = PAGE_ALIGN(buf_size);
     buffer_num_pages = page_aligned_buf_size / PAGE_SIZE;
     buffer_pages = kcalloc(buffer_num_pages, sizeof(struct page *), GFP_KERNEL);
@@ -61,7 +61,7 @@ static int hrp_alloc_rb_buf(HrperfRingBuffer *rb) {
 #else
     buf = kmalloc(buf_size, GFP_KERNEL | __GFP_ZERO);
     if (!buf) {
-        pr_err("hrperf: Failed to allocate buffer of size %zu for rb on cpu %d\n", buf_size, cpu);
+        pr_err("hrperf: Failed to allocate buffer of size %zu for rb\n", buf_size);
         return -ENOMEM;
     }
 #endif
@@ -76,7 +76,7 @@ inline __attribute__((always_inline)) bool is_full(const HrperfRingBuffer *rb) {
 inline __attribute__((always_inline)) int init_ring_buffer(HrperfRingBuffer *rb) {
     rb->head = 0;
     rb->tail = 0;
-#ifdef HRP_HEAP_ALLOCATED_RB
+#if HRP_HEAP_ALLOCATED_RB
     int r = hrp_alloc_rb_buf(rb);
     return r;
 #else

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -29,6 +29,7 @@ static void free_alloc_pages(void) {
 }
 #endif
 
+#if HRP_HEAP_ALLOCATED_RB
 static int hrp_alloc_rb_buf(HrperfRingBuffer *rb) {
     HrperfLogEntry *buf = NULL;
     size_t buf_size = HRP_PMC_BUFFER_SIZE * sizeof(HrperfLogEntry);
@@ -68,6 +69,7 @@ static int hrp_alloc_rb_buf(HrperfRingBuffer *rb) {
     rb->buffer = buf;
     return 0;
 }
+#endif
 
 inline __attribute__((always_inline)) bool is_full(const HrperfRingBuffer *rb) {
     return ((rb->tail + 1) % HRP_PMC_BUFFER_SIZE) == rb->head;

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -13,7 +13,7 @@ typedef struct {
     unsigned long long cpu_unhalt;
     unsigned long long llc_misses;
     unsigned long long sw_prefetch;
-#ifdef HRP_LOG_IMC
+#if HRP_LOG_IMC
     unsigned long long imc_reads;
     unsigned long long imc_writes;
 #endif
@@ -25,7 +25,7 @@ typedef struct __attribute__((__packed__)) {
 } HrperfLogEntry;
 
 typedef struct {
-#ifdef HRP_HEAP_ALLOCATED_RB
+#if HRP_HEAP_ALLOCATED_RB
     HrperfLogEntry *buffer;
 #else
     HrperfLogEntry buffer[HRP_PMC_BUFFER_SIZE];

--- a/src/config.h
+++ b/src/config.h
@@ -20,6 +20,16 @@
 #define HRP_PMC_LOGGER_CPU 0
 #define HRP_PMC_POLLER_CPU 1
 
+// Set to 1 to enforce strict synchronization across all PMU polling
+// When enabled, all poller functions across all CPUs will use a barrier 
+// to synchronize the start. Therefore, this mechanism can maximally 
+// reduce the time difference across PMU polling on different CPUs.
+#define HRP_STRICT_POLLING_SYNC 1
+
+// Set to 1 to also poll the PMUs on the core where the poller job is executed.
+// If set to 0, the poller core will not poll its own PMUs.
+#define HRP_POLL_POLLER_CORE 1
+
 // set to 1 for ktime_get_raw(), 0 for ktime_get_real()
 // LDB timestamps use the raw clock, also corresponding to perf sched record -k CLOCK_MONOTONIC_RAW
 #define HRP_USE_RAW_CLOCK 0

--- a/src/config.h
+++ b/src/config.h
@@ -99,10 +99,12 @@ static const unsigned long hrp_pmc_cpu_selection_mask_bits[HRP_PMC_CPU_SELECTION
 #define HRP_PMC_DEVICE_NAME "hrperf_device"
 #define HRP_PMC_CLASS_NAME "hrperf_class"
 #define HRP_PMC_IOC_MAGIC  'k'
-#define HRP_PMC_IOC_START           _IO(HRP_PMC_IOC_MAGIC, 1)
-#define HRP_PMC_IOC_PAUSE           _IO(HRP_PMC_IOC_MAGIC, 2)
-#define HRP_PMC_IOC_INSTRUCTED_LOG  _IO(HRP_PMC_IOC_MAGIC, 3)
-#define HRP_PMC_IOC_TSC_FREQ        _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
+#define HRP_PMC_IOC_START                   _IO(HRP_PMC_IOC_MAGIC, 1)
+#define HRP_PMC_IOC_PAUSE                   _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_INSTRUCTED_POLL         _IO(HRP_PMC_IOC_MAGIC, 3)
+#define HRP_PMC_IOC_INSTRUCTED_LOG          _IO(HRP_PMC_IOC_MAGIC, 4)
+#define HRP_PMC_IOC_INSTRUCTED_POLL_AND_LOG _IO(HRP_PMC_IOC_MAGIC, 5)
+#define HRP_PMC_IOC_TSC_FREQ                _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
 
 /*
     BPF Component Configurations, CURRENTLY NOT USED!

--- a/src/config.h
+++ b/src/config.h
@@ -89,9 +89,10 @@ static const unsigned long hrp_pmc_cpu_selection_mask_bits[HRP_PMC_CPU_SELECTION
 #define HRP_PMC_DEVICE_NAME "hrperf_device"
 #define HRP_PMC_CLASS_NAME "hrperf_class"
 #define HRP_PMC_IOC_MAGIC  'k'
-#define HRP_PMC_IOC_START       _IO(HRP_PMC_IOC_MAGIC, 1)
-#define HRP_PMC_IOC_PAUSE       _IO(HRP_PMC_IOC_MAGIC, 2)
-#define HRP_PMC_IOC_TSC_FREQ    _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
+#define HRP_PMC_IOC_START           _IO(HRP_PMC_IOC_MAGIC, 1)
+#define HRP_PMC_IOC_PAUSE           _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_INSTRUCTED_LOG  _IO(HRP_PMC_IOC_MAGIC, 3)
+#define HRP_PMC_IOC_TSC_FREQ        _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
 
 /*
     BPF Component Configurations, CURRENTLY NOT USED!

--- a/src/hrperf.c
+++ b/src/hrperf.c
@@ -124,7 +124,6 @@ static void hrperf_poller_func(void *info) {
 
   HrperfLogEntry entry;
   entry.cpu_id = smp_processor_id();
-  pr_info("hrperf: CPU %d polled.\n", entry.cpu_id);
   hrperf_poller_data_t *data = (hrperf_poller_data_t *)info;
   entry.tick.kts = data->kts;
   rdmsrl(MSR_IA32_PMC2, entry.tick.stall_mem);
@@ -178,8 +177,6 @@ static __always_inline void smp_poll_pmus(hrperf_poller_data_t *poller_data) {
 
   smp_call_function_many(&hrp_selected_cpus, hrperf_poller_func,
                          (void *)poller_data, 0);
-  
-  pr_info("hrperf: All poller threads dispatched.\n");
 #if HRP_POLL_POLLER_CORE
   // Current CPU also participates
   atomic_inc(&ready_cpus);
@@ -248,8 +245,6 @@ static int hrperf_logger_thread(void *arg) {
 }
 
 static void instructed_log_op(struct work_struct *work) {
-  pr_info("hrperf: Instructed log operation started on CPU %d\n",
-          smp_processor_id());
   hrperf_poller_data_t poller_data;
   poller_data.kts = 0; // Initialize kts to 0, will be set in the poller
   smp_poll_pmus(&poller_data);

--- a/workloads/hrperf_api.h
+++ b/workloads/hrperf_api.h
@@ -10,9 +10,10 @@
 #define u64 uint64_t
 
 #define HRP_PMC_IOC_MAGIC 'k'
-#define HRP_PMC_IOC_START       _IO(HRP_PMC_IOC_MAGIC, 1)
-#define HRP_IOC_STOP            _IO(HRP_PMC_IOC_MAGIC, 2)
-#define HRP_PMC_IOC_TSC_FREQ    _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
+#define HRP_PMC_IOC_START           _IO(HRP_PMC_IOC_MAGIC, 1)
+#define HRP_IOC_STOP                _IO(HRP_PMC_IOC_MAGIC, 2)
+#define HRP_PMC_IOC_INSTRUCTED_LOG  _IO(HRP_PMC_IOC_MAGIC, 3)
+#define HRP_PMC_IOC_TSC_FREQ        _IOR(HRP_PMC_IOC_MAGIC, 10, u64)
 
 int hrperf_start() {
     int fd;
@@ -81,6 +82,26 @@ u64 hrperf_get_tsc_freq() {
 
     close(fd);
     return tsc_freq;
+}
+
+/*
+ * Instruct the hiresperf to perform exactly one poll and log operation.
+*/
+void hrperf_instruct_log() {
+    int fd;
+
+    // Open the device file
+    fd = open("/dev/hrperf_device", O_RDWR);
+    if (fd < 0) {
+        perror("open");
+    }
+
+    // Get the TSC frequency
+    if (ioctl(fd, HRP_PMC_IOC_INSTRUCTED_LOG) < 0) {
+        perror("ioctl");
+        close(fd);
+    }
+    close(fd);
 }
 
 // for the bpf component

--- a/workloads/instruct_log.c
+++ b/workloads/instruct_log.c
@@ -1,0 +1,6 @@
+#include "hrperf_api.h"
+
+int main() {
+    hrperf_instruct_log();
+    return 0;
+}

--- a/workloads/instruct_poll.c
+++ b/workloads/instruct_poll.c
@@ -1,0 +1,6 @@
+#include "hrperf_api.h"
+
+int main() {
+    hrperf_instruct_poll();
+    return 0;
+}

--- a/workloads/instruct_poll_log.c
+++ b/workloads/instruct_poll_log.c
@@ -1,0 +1,6 @@
+#include "hrperf_api.h"
+
+int main() {
+    hrperf_instruct_poll_and_log();
+    return 0;
+}


### PR DESCRIPTION
This one is based on #11, we shall review this afterwards.

## New changes:

### New `instructed_profile` mode
  In instructed profile mode, the hrperf will only log a set of data when it is instructed to do so. In this mode, the poller thread and logger thread are never created. Such instruction is done via an `ioctl`. 

### Support polling the poller core' PMUs
  The poller core invokes `smp_call_function_many` to execute polling logic across multiple cores. However, `smp_call_function_many` skips the executing core. In the case where we want to all PMU readings from all cores, this is rather undesired.

### Support synchronized polling
  Synchronized polling uses a barrier to maximally ensure the counter reading across all cores happens at the same time (it can still drift from each other).
  
  
## New Flags in `config.h`:
``` c
// Set to 1 to enforce strict synchronization across all PMU polling
// When enabled, all poller functions across all CPUs will use a barrier 
// to synchronize the start. Therefore, this mechanism can maximally 
// reduce the time difference across PMU polling on different CPUs.
#define HRP_STRICT_POLLING_SYNC 1

// Set to 1 to also poll the PMUs on the core where the poller job is executed.
// If set to 0, the poller core will not poll its own PMUs.
#define HRP_POLL_POLLER_CORE 1
```


## Note:
The instructed logging in the `instructed_profile` mode also respects the poller core setting in the `config.h`. The ioctl handler will delegate the execution to the specific core defined in the `config.h`.