### PR TITLE
fix(readme): remove sudo in a few places

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The other way is to manually toggle it by
 ```
 cd workloads
 make
+# or `sudo ./start` if you didn't run `sudo chmod 666 /dev/hrperf_device` beforehand.
 ./start
 ```
 Either way it's just using `ioctl` to interact with the kernel module.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Before building hiresperf, check and edit `src/config.h` carefully to make hardw
 
 **Build and install hiresperf**
 ```
-sudo make
-sudo make install
+make
+make install
 ```
 **Setup/cleanup the hiresperf kernel module**
 


### PR DESCRIPTION
There was a change introduced in a07ded8156dab06183b1ced60967fa50d7621aa5, which removed the `PWD := $(shell pwd)`.

`$PWD` is a shell-populated environment variable, and we shall not override it with shell commands. This causes trouble (if we override with the shell `pwd` command) when we need to include our own header files with `ccflags-y` in kernel code. As the `PWD` variable is carried into the kernel build dir without expansion, and results in a wrong path.

Therefore, `PWD := $(shell pwd)` is removed. However, `sudo make` cannot handle this correctly. Moreover, `sudo make clean` can have serious trouble by mistakenly cleaning up kernel header files, as `sudo` changes the environment variables in a different way, leading to an empty replacement for `$PWD`.

Nevertheless, `sudo` should not be used for building a kernel module per https://docs.kernel.org/kbuild/modules.html, as it can have wrong behavior.